### PR TITLE
SQL logs improvement

### DIFF
--- a/adapters/bigquery.go
+++ b/adapters/bigquery.go
@@ -166,8 +166,8 @@ func (bq *BigQuery) PatchTableSchema(patchSchema *Table) error {
 		}
 		metadata.Schema = append(metadata.Schema, &bigquery.FieldSchema{Name: columnName, Type: bigQueryType})
 	}
-
 	updateReq := bigquery.TableMetadataToUpdate{Schema: metadata.Schema}
+	bq.logQuery("Patch update request: ", updateReq, true)
 	if _, err := bqTable.Update(bq.ctx, updateReq, metadata.ETag); err != nil {
 		var columns []string
 		for _, column := range metadata.Schema {

--- a/adapters/bigquery.go
+++ b/adapters/bigquery.go
@@ -184,7 +184,7 @@ func (bq *BigQuery) logQuery(messageTemplate string, entity interface{}) {
 	if err != nil {
 		logging.Warnf("Failed to serialize entity for logging: %s", fmt.Sprint(entity))
 	} else {
-		bq.queryLogger.Log(messageTemplate + string(entityJson))
+		bq.queryLogger.LogQuery(messageTemplate + string(entityJson))
 	}
 }
 

--- a/adapters/clickhouse.go
+++ b/adapters/clickhouse.go
@@ -454,7 +454,7 @@ func (ch *ClickHouse) deleteInTransaction(wrappedTx *Transaction, table *Table, 
 	if err != nil {
 		return fmt.Errorf("Error preparing delete statement [%s]: %v", deleteQuery, err)
 	}
-	ch.queryLogger.LogWithValues(deleteQuery, values)
+	ch.queryLogger.LogQueryWithValues(deleteQuery, values)
 	_, err = deleteStmt.ExecContext(ch.ctx, values...)
 	if err != nil {
 		return fmt.Errorf("Error deleting using query: %s, error: %v", deleteQuery, err)

--- a/adapters/clickhouse.go
+++ b/adapters/clickhouse.go
@@ -273,7 +273,7 @@ func (ch *ClickHouse) CreateDB(dbName string) error {
 	}
 
 	query := fmt.Sprintf(createCHDBTemplate, dbName, ch.getOnClusterClause())
-	ch.queryLogger.Log(query)
+	ch.queryLogger.LogDDL(query)
 	createStmt, err := wrappedTx.tx.PrepareContext(ch.ctx, query)
 	if err != nil {
 		return fmt.Errorf("Error preparing create db %s statement: %v", dbName, err)
@@ -312,7 +312,7 @@ func (ch *ClickHouse) CreateTable(tableSchema *Table) error {
 	//sorting columns asc
 	sort.Strings(columnsDDL)
 	statementStr := ch.tableStatementFactory.CreateTableStatement(tableSchema.Name, strings.Join(columnsDDL, ","))
-	ch.queryLogger.Log(statementStr)
+	ch.queryLogger.LogDDL(statementStr)
 
 	_, err := ch.dataSource.ExecContext(ch.ctx, statementStr)
 	if err != nil {
@@ -375,7 +375,7 @@ func (ch *ClickHouse) PatchTableSchema(patchSchema *Table) error {
 			columnTypeDDL = sqlType
 		}
 		query := fmt.Sprintf(addColumnCHTemplate, ch.database, patchSchema.Name, ch.getOnClusterClause(), columnName, columnTypeDDL)
-		ch.queryLogger.Log(query)
+		ch.queryLogger.LogDDL(query)
 		alterStmt, err := wrappedTx.tx.PrepareContext(ch.ctx, query)
 		if err != nil {
 			wrappedTx.Rollback()
@@ -414,7 +414,7 @@ func (ch *ClickHouse) Insert(table *Table, valuesMap map[string]interface{}) err
 	}
 
 	query := fmt.Sprintf(insertCHTemplate, ch.database, table.Name, strings.Join(header, ", "), strings.Join(placeholders, ", "))
-	ch.queryLogger.LogWithValues(query, values)
+	ch.queryLogger.LogQueryWithValues(query, values)
 	insertStmt, err := wrappedTx.tx.PrepareContext(ch.ctx, query)
 	if err != nil {
 		wrappedTx.Rollback()
@@ -469,7 +469,7 @@ func (ch *ClickHouse) BulkInsert(table *Table, objects []map[string]interface{})
 			}
 		}
 
-		ch.queryLogger.LogWithValues(query, values)
+		ch.queryLogger.LogQueryWithValues(query, values)
 
 		_, err = insertStmt.ExecContext(ch.ctx, values...)
 		if err != nil {
@@ -503,7 +503,7 @@ func (ch *ClickHouse) getOnClusterClause() string {
 func (ch *ClickHouse) createDistributedTableInTransaction(originTableName string) {
 	statement := fmt.Sprintf(createDistributedTableCHTemplate,
 		ch.database, originTableName, ch.getOnClusterClause(), ch.database, originTableName, ch.cluster, ch.database, originTableName)
-	ch.queryLogger.Log(statement)
+	ch.queryLogger.LogDDL(statement)
 
 	_, err := ch.dataSource.ExecContext(ch.ctx, statement)
 	if err != nil {
@@ -515,7 +515,7 @@ func (ch *ClickHouse) createDistributedTableInTransaction(originTableName string
 //drop distributed table, ignore errors
 func (ch *ClickHouse) dropDistributedTableInTransaction(wrappedTx *Transaction, originTableName string) {
 	query := fmt.Sprintf(dropDistributedTableCHTemplate, ch.database, originTableName, ch.getOnClusterClause())
-	ch.queryLogger.Log(query)
+	ch.queryLogger.LogDDL(query)
 	createStmt, err := wrappedTx.tx.PrepareContext(ch.ctx, query)
 	if err != nil {
 		logging.Errorf("Error preparing drop distributed table statement for [%s] : %v", originTableName, err)

--- a/adapters/google_analytics.go
+++ b/adapters/google_analytics.go
@@ -100,7 +100,7 @@ func (ga GoogleAnalytics) Send(object map[string]interface{}) error {
 	}
 
 	reqUrl := "https://www.google-analytics.com/collect?" + uv.Encode()
-	ga.debugLogger.Log(reqUrl)
+	ga.debugLogger.LogQuery(reqUrl)
 
 	r, err := ga.client.Get(reqUrl)
 	if r != nil && r.Body != nil {

--- a/adapters/postgres.go
+++ b/adapters/postgres.go
@@ -428,7 +428,7 @@ func (p *Postgres) BulkUpdate(table *Table, objects []map[string]interface{}, de
 func (p *Postgres) deleteInTransaction(wrappedTx *Transaction, table *Table, deleteConditions *DeleteConditions) error {
 	deleteCondition, values := p.toDeleteQuery(deleteConditions)
 	query := fmt.Sprintf(deleteQueryTemplate, p.config.Schema, table.Name, deleteCondition)
-	p.queryLogger.LogWithValues(query, values)
+	p.queryLogger.LogQueryWithValues(query, values)
 	deleteStmt, err := wrappedTx.tx.PrepareContext(p.ctx, query)
 	if err != nil {
 		return fmt.Errorf("Error preparing delete table %s statement: %v", table.Name, err)

--- a/adapters/snowflake.go
+++ b/adapters/snowflake.go
@@ -163,7 +163,7 @@ func (s *Snowflake) CreateTable(tableSchema *Table) error {
 	//sorting columns asc
 	sort.Strings(columnsDDL)
 	query := fmt.Sprintf(createSFTableTemplate, s.config.Schema, reformatValue(tableSchema.Name), strings.Join(columnsDDL, ","))
-	s.queryLogger.Log(query)
+	s.queryLogger.LogDDL(query)
 	createStmt, err := wrappedTx.tx.PrepareContext(s.ctx, query)
 	if err != nil {
 		wrappedTx.Rollback()
@@ -194,7 +194,7 @@ func (s *Snowflake) PatchTableSchema(patchSchema *Table) error {
 		}
 		query := fmt.Sprintf(addSFColumnTemplate, s.config.Schema,
 			reformatValue(patchSchema.Name), reformatValue(columnName), sqlType)
-		s.queryLogger.Log(query)
+		s.queryLogger.LogDDL(query)
 		alterStmt, err := wrappedTx.tx.PrepareContext(s.ctx, query)
 		if err != nil {
 			wrappedTx.Rollback()
@@ -289,7 +289,7 @@ func (s *Snowflake) Insert(table *Table, valuesMap map[string]interface{}) error
 	placeholders = removeLastComma(placeholders)
 
 	query := fmt.Sprintf(insertSFTemplate, s.config.Schema, reformatValue(table.Name), header, placeholders)
-	s.queryLogger.LogWithValues(query, values)
+	s.queryLogger.LogQueryWithValues(query, values)
 
 	wrappedTx, err := s.OpenTx()
 	if err != nil {

--- a/destinations/service_test.go
+++ b/destinations/service_test.go
@@ -113,7 +113,7 @@ func TestServiceInit(t *testing.T) {
 
 	eventsCache := caching.NewEventsCache(&meta.Dummy{}, 100)
 	service, err := NewService(context.Background(), nil, mockDestinationsServer.URL, "/tmp",
-		nil, eventsCache, logging.NewFactory("/tmp", 5, false, nil), createTestStorage)
+		nil, eventsCache, logging.NewFactory("/tmp", 5, false, nil, nil), createTestStorage)
 	require.NoError(t, err)
 	require.NotNil(t, service)
 

--- a/integration_tests/postgres_primary_keys_test.go
+++ b/integration_tests/postgres_primary_keys_test.go
@@ -29,7 +29,7 @@ func TestPrimaryKeyRemoval(t *testing.T) {
 
 	enrichment.InitDefault()
 	dsConfig := &adapters.DataSourceConfig{Host: container.Host, Port: container.Port, Db: container.Database, Schema: container.Schema, Username: container.Username, Password: container.Password, Parameters: map[string]string{"sslmode": "disable"}}
-	pg, err := adapters.NewPostgres(ctx, dsConfig, logging.NewQueryLogger("test", nil), map[string]string{})
+	pg, err := adapters.NewPostgres(ctx, dsConfig, logging.NewQueryLogger("test", nil, nil), map[string]string{})
 	require.NoError(t, err)
 	require.NotNil(t, pg)
 

--- a/logging/factory.go
+++ b/logging/factory.go
@@ -11,14 +11,16 @@ type Factory struct {
 	logRotationMin int64
 	showInServer   bool
 
+	ddlLogsWriter   io.Writer
 	queryLogsWriter io.Writer
 }
 
-func NewFactory(logEventPath string, logRotationMin int64, showInServer bool, queryLogsWriter io.Writer) *Factory {
+func NewFactory(logEventPath string, logRotationMin int64, showInServer bool, ddlLogsWriter io.Writer, queryLogsWriter io.Writer) *Factory {
 	return &Factory{
 		logEventPath:    logEventPath,
 		logRotationMin:  logRotationMin,
 		showInServer:    showInServer,
+		ddlLogsWriter:   ddlLogsWriter,
 		queryLogsWriter: queryLogsWriter,
 	}
 }
@@ -44,7 +46,7 @@ func (f *Factory) CreateFailedLogger(destinationName string) *AsyncLogger {
 }
 
 func (f *Factory) CreateSQLQueryLogger(destinationName string) *QueryLogger {
-	return NewQueryLogger(destinationName, f.queryLogsWriter)
+	return NewQueryLogger(destinationName, f.ddlLogsWriter, f.queryLogsWriter)
 }
 
 func (f *Factory) CreateStreamingArchiveLogger(destinationName string) *AsyncLogger {

--- a/logging/query_logger.go
+++ b/logging/query_logger.go
@@ -8,30 +8,41 @@ import (
 )
 
 type QueryLogger struct {
-	logger     *log.Logger
-	identifier string
+	queryLogger *log.Logger
+	ddlLogger   *log.Logger
+	identifier  string
 }
 
-func NewQueryLogger(identifier string, writer io.Writer) *QueryLogger {
-	var logger *log.Logger
-	if writer != nil {
-		logger = log.New(DateTimeWriterProxy{writer: writer}, "", 0)
+func NewQueryLogger(identifier string, ddlWriter io.Writer, queryWriter io.Writer) *QueryLogger {
+	var queryLogger *log.Logger
+	if queryWriter != nil {
+		queryLogger = log.New(DateTimeWriterProxy{writer: queryWriter}, "", 0)
 	}
-	return &QueryLogger{identifier: identifier, logger: logger}
+	var ddlLogger *log.Logger
+	if ddlWriter != nil {
+		ddlLogger = log.New(DateTimeWriterProxy{writer: ddlWriter}, "", 0)
+	}
+	return &QueryLogger{identifier: identifier, queryLogger: queryLogger, ddlLogger: ddlLogger}
 }
 
-func (l *QueryLogger) Log(query string) {
-	if l.logger != nil {
-		l.logger.Printf("%s [%s] %s\n", debugPrefix, l.identifier, query)
+func (l *QueryLogger) LogDDL(query string) {
+	if l.ddlLogger != nil {
+		l.ddlLogger.Printf("%s [%s] %s\n", debugPrefix, l.identifier, query)
 	}
 }
 
-func (l *QueryLogger) LogWithValues(query string, values []interface{}) {
-	if l.logger != nil {
+func (l *QueryLogger) LogQuery(query string) {
+	if l.queryLogger != nil {
+		l.queryLogger.Printf("%s [%s] %s\n", debugPrefix, l.identifier, query)
+	}
+}
+
+func (l *QueryLogger) LogQueryWithValues(query string, values []interface{}) {
+	if l.queryLogger != nil {
 		var stringValues []string
 		for _, value := range values {
 			stringValues = append(stringValues, fmt.Sprint(value))
 		}
-		l.logger.Printf("%s [%s] %s; values: [%s]\n", debugPrefix, l.identifier, query, strings.Join(stringValues, ", "))
+		l.queryLogger.Printf("%s [%s] %s; values: [%s]\n", debugPrefix, l.identifier, query, strings.Join(stringValues, ", "))
 	}
 }

--- a/main.go
+++ b/main.go
@@ -147,7 +147,8 @@ func main() {
 	}
 	logRotationMin := viper.GetInt64("log.rotation_min")
 
-	loggerFactory := logging.NewFactory(logEventPath, logRotationMin, viper.GetBool("log.show_in_server"), appconfig.Instance.QueryLogsWriter)
+	loggerFactory := logging.NewFactory(logEventPath, logRotationMin, viper.GetBool("log.show_in_server"),
+		appconfig.Instance.DDLLogsWriter, appconfig.Instance.QueryLogsWriter)
 
 	//synchronization service
 	syncService, err := synchronization.NewService(

--- a/main_test.go
+++ b/main_test.go
@@ -439,7 +439,7 @@ func testPostgresStoreEvents(t *testing.T, pgDestinationConfigTemplate string, e
 	enrichment.InitDefault()
 	monitor := synchronization.NewInMemoryService([]string{})
 	eventsCache := caching.NewEventsCache(&meta.Dummy{}, 100)
-	dest, err := destinations.NewService(ctx, nil, destinationConfig, "/tmp", monitor, eventsCache, logging.NewFactory("/tmp", 5, false, nil), storages.Create)
+	dest, err := destinations.NewService(ctx, nil, destinationConfig, "/tmp", monitor, eventsCache, logging.NewFactory("/tmp", 5, false, nil, nil), storages.Create)
 	require.NoError(t, err)
 	defer dest.Close()
 
@@ -538,7 +538,7 @@ func testClickhouseStoreEvents(t *testing.T, configTemplate string, expectedEven
 
 	monitor := synchronization.NewInMemoryService([]string{})
 	eventsCache := caching.NewEventsCache(&meta.Dummy{}, 100)
-	dest, err := destinations.NewService(ctx, nil, destinationConfig, "/tmp", monitor, eventsCache, logging.NewFactory("/tmp", 5, false, nil), storages.Create)
+	dest, err := destinations.NewService(ctx, nil, destinationConfig, "/tmp", monitor, eventsCache, logging.NewFactory("/tmp", 5, false, nil, nil), storages.Create)
 	require.NoError(t, err)
 	defer dest.Close()
 	router := SetupRouter(dest, "", synchronization.NewInMemoryService([]string{}), eventsCache, events.NewCache(5), sources.NewTestService(), fallback.NewTestService())


### PR DESCRIPTION
Split sql debug logging configuration: 'ddl' section configures only DDL-related queries while 'queries' configures all the data manipulations (CRUD operations)