### PR TITLE
Setup application directory as working directory

### DIFF
--- a/main.go
+++ b/main.go
@@ -6,6 +6,16 @@ import (
 	"errors"
 	"flag"
 	"fmt"
+	"math/rand"
+	"net/http"
+	"os"
+	"os/signal"
+	"path/filepath"
+	"runtime/debug"
+	"strings"
+	"syscall"
+	"time"
+
 	"github.com/gin-gonic/gin/binding"
 	"github.com/jitsucom/eventnative/appconfig"
 	"github.com/jitsucom/eventnative/appstatus"
@@ -30,14 +40,6 @@ import (
 	"github.com/jitsucom/eventnative/synchronization"
 	"github.com/jitsucom/eventnative/telemetry"
 	"github.com/jitsucom/eventnative/users"
-	"math/rand"
-	"net/http"
-	"os"
-	"os/signal"
-	"runtime/debug"
-	"strings"
-	"syscall"
-	"time"
 
 	"github.com/spf13/viper"
 )
@@ -134,6 +136,19 @@ func handleConfigErr(err error) error {
 	return nil
 }
 
+func setAppWorkDir() {
+	application, err := os.Executable()
+	if err != nil {
+		logging.Errorf("Cannot get executable information: %v", err)
+	}
+
+	directory := filepath.Dir(application)
+
+	if err = os.Chdir(directory); err != nil {
+		logging.Errorf("Cannot setup working directory %v: %v", directory, err)
+	}
+}
+
 func main() {
 	//Setup seed for globalRand
 	rand.Seed(time.Now().Unix())
@@ -143,6 +158,9 @@ func main() {
 
 	//Setup default timezone for time.Now() calls
 	time.Local = time.UTC
+
+	// Setup application directory as working directory
+	setAppWorkDir()
 
 	if err := readInViperConfig(); err != nil {
 		logging.Fatal("Error while reading application config:", err)


### PR DESCRIPTION
Fix allows using paths relative to the application file, but not to place from it was launched.
Fixes #122 