### PR TITLE
158. Validate stage permissions on test connection

### DIFF
--- a/adapters/s3.go
+++ b/adapters/s3.go
@@ -153,23 +153,13 @@ func (a *S3) DeleteObject(key string) error {
 // Function tries to create temporary file and remove it.
 // Returns OK if file creation was successfull.
 func (a *S3) ValidateWritePermission() error {
-	filename := fmt.Sprintf("%v/test_%v", a.config.Folder, timestamp.NowUTC())
+	filename := fmt.Sprintf("test_%v", timestamp.NowUTC())
 
-	creation := &s3.PutObjectInput{
-		Bucket: &a.config.Bucket,
-		Key:    &filename,
-	}
-	_, err := a.client.PutObject(creation)
-	if err != nil {
+	if err := a.UploadBytes(filename, []byte{}); err != nil {
 		return err
 	}
 
-	deletion := &s3.DeleteObjectInput{
-		Bucket: &a.config.Bucket,
-		Key:    &filename,
-	}
-	_, err = a.client.DeleteObject(deletion)
-	if err != nil {
+	if err := a.DeleteObject(filename); err != nil {
 		logging.Warnf("Cannot remove object %q from S3: %v", filename, err)
 		// Suppressing error because we need to check only write permission
 		// return err

--- a/adapters/s3.go
+++ b/adapters/s3.go
@@ -4,12 +4,15 @@ import (
 	"bytes"
 	"errors"
 	"fmt"
+	"io"
+	"net/http"
+
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/aws/credentials"
 	"github.com/aws/aws-sdk-go/aws/session"
 	"github.com/aws/aws-sdk-go/service/s3"
-	"io"
-	"net/http"
+	"github.com/jitsucom/eventnative/logging"
+	"github.com/jitsucom/eventnative/timestamp"
 )
 
 type S3 struct {
@@ -142,6 +145,34 @@ func (a *S3) DeleteObject(key string) error {
 
 	if output != nil && output.DeleteMarker != nil && !*(output.DeleteMarker) {
 		return fmt.Errorf("Key %s wasn't deleted from s3", key)
+	}
+
+	return nil
+}
+
+// Function tries to create temporary file and remove it.
+// Returns OK if file creation was successfull.
+func (a *S3) ValidateWritePermission() error {
+	filename := fmt.Sprintf("%v/test_%v", a.config.Folder, timestamp.NowUTC())
+
+	creation := &s3.PutObjectInput{
+		Bucket: &a.config.Bucket,
+		Key:    &filename,
+	}
+	_, err := a.client.PutObject(creation)
+	if err != nil {
+		return err
+	}
+
+	deletion := &s3.DeleteObjectInput{
+		Bucket: &a.config.Bucket,
+		Key:    &filename,
+	}
+	_, err = a.client.DeleteObject(deletion)
+	if err != nil {
+		logging.Warnf("Cannot remove object %q from S3: %v", filename, err)
+		// Suppressing error because we need to check only write permission
+		// return err
 	}
 
 	return nil

--- a/handlers/destinations.go
+++ b/handlers/destinations.go
@@ -3,14 +3,15 @@ package handlers
 import (
 	"context"
 	"errors"
+	"net/http"
+	"strings"
+
 	"github.com/gin-gonic/gin"
 	"github.com/hashicorp/go-multierror"
 	"github.com/jitsucom/eventnative/adapters"
 	"github.com/jitsucom/eventnative/logging"
 	"github.com/jitsucom/eventnative/middleware"
 	"github.com/jitsucom/eventnative/storages"
-	"net/http"
-	"strings"
 )
 
 func DestinationsHandler(c *gin.Context) {
@@ -72,7 +73,11 @@ func testConnection(config *storages.DestinationConfig) error {
 			if err != nil {
 				return err
 			}
-			s3.Close()
+			defer s3.Close()
+			err = s3.ValidateWritePermission()
+			if err != nil {
+				return err
+			}
 		}
 
 		redshift, err := adapters.NewAwsRedshift(context.Background(), config.DataSource, config.S3, nil, map[string]string{})
@@ -119,6 +124,10 @@ func testConnection(config *storages.DestinationConfig) error {
 					return err
 				}
 				defer s3.Close()
+				err = s3.ValidateWritePermission()
+				if err != nil {
+					return err
+				}
 			} else if config.Google != nil && config.Google.Bucket != "" {
 				if err := config.Google.Validate(false); err != nil {
 					return err

--- a/handlers/destinations.go
+++ b/handlers/destinations.go
@@ -74,8 +74,7 @@ func testConnection(config *storages.DestinationConfig) error {
 				return err
 			}
 			defer s3.Close()
-			err = s3.ValidateWritePermission()
-			if err != nil {
+			if err = s3.ValidateWritePermission(); err != nil {
 				return err
 			}
 		}
@@ -103,6 +102,9 @@ func testConnection(config *storages.DestinationConfig) error {
 				return err
 			}
 			defer googleStorage.Close()
+			if err = googleStorage.ValidateWritePermission(); err != nil {
+				return nil
+			}
 		}
 		return bq.Test()
 	case storages.SnowflakeType:
@@ -124,8 +126,7 @@ func testConnection(config *storages.DestinationConfig) error {
 					return err
 				}
 				defer s3.Close()
-				err = s3.ValidateWritePermission()
-				if err != nil {
+				if err = s3.ValidateWritePermission(); err != nil {
 					return err
 				}
 			} else if config.Google != nil && config.Google.Bucket != "" {
@@ -137,6 +138,9 @@ func testConnection(config *storages.DestinationConfig) error {
 					return err
 				}
 				defer gcp.Close()
+				if err = gcp.ValidateWritePermission(); err != nil {
+					return err
+				}
 			}
 		}
 		return nil


### PR DESCRIPTION
Fixes #158
* Adding function for validating WRITE permissions on S3
* Adding permission S3 validation on batch mode at TestConnection to RedShift
* Adding permission S3 validation on batch mode at TestConnection to Snowflake
* Adding function for validating WRITE permissions on Google Cloud Storage
* Adding permission GCS validation on batch mode at TestConnection to BigQuery
* Adding permission GCS validation on batch mode at TestConnection to Snowflake